### PR TITLE
fix nvim-tree toggle call

### DIFF
--- a/lua/auto-session-nvim-tree-hooks.lua
+++ b/lua/auto-session-nvim-tree-hooks.lua
@@ -11,7 +11,7 @@ local function refresh_tree()
       if (tree_type == "nvimtree") then
         pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
         -- want no focus to avoid "'modifiable' is off" errors
-        require('nvim-tree').toggle(false, true)
+        require('nvim-tree.api').tree.toggle(false, true)
       elseif (tree_type == "nerdtree") then
         pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
         vim.cmd 'NERDTreeOpen'


### PR DESCRIPTION
I am not sure if the nvim-tree API has changed or if there was a typo from the start, but now you need to toggle nvim-tree like this for everything to work correctly.